### PR TITLE
Fixing deletion problem

### DIFF
--- a/api_yamdb/api/serializers.py
+++ b/api_yamdb/api/serializers.py
@@ -74,13 +74,6 @@ class ReviewSerializer(serializers.ModelSerializer):
     class Meta:
         fields = ('id', 'text', 'author', 'score', 'pub_date', 'title')
         model = Review
-        # validators = [
-        #     serializers.UniqueTogetherValidator(
-        #         queryset=Review.objects.all(),
-        #         fields=['title', 'author'],
-        #         message='Вы уже оставляли отзыв.'
-        #     )
-        # ]
 
 
 class CommentSerializer(serializers.ModelSerializer):

--- a/api_yamdb/api/views.py
+++ b/api_yamdb/api/views.py
@@ -69,6 +69,7 @@ class CategoryViewSet(ListCreateDestroyViewSet):
         SearchFilter,
     )
     search_fields = ('name',)
+    lookup_field = 'slug'
 
 
 class GenreViewSet(ListCreateDestroyViewSet):
@@ -81,12 +82,12 @@ class GenreViewSet(ListCreateDestroyViewSet):
         SearchFilter,
     )
     search_fields = ('name',)
+    lookup_field = 'slug'
 
 
 class ReviewViewSet(viewsets.ModelViewSet):
     serializer_class = ReviewSerializer
     permission_classes = (AuthorAndStaffOrReadOnly,)
-    # pagination_class = CommentPagination
 
     def get_queryset(self):
         title = get_object_or_404(Title, id=self.kwargs.get("title_id"))

--- a/api_yamdb/reviews/models.py
+++ b/api_yamdb/reviews/models.py
@@ -106,12 +106,6 @@ class Review(PostModel):
         verbose_name = 'Отзыв'
         verbose_name_plural = 'Отзывы'
         ordering = ['-id']
-        # constraints = [
-        #     models.UniqueConstraint(
-        #         fields=['title', 'author'],
-        #         name='unique_title_author'
-        #     )
-        # ]
 
     def __str__(self):
         return (f'{self.author} отозвался о произведении '


### PR DESCRIPTION
Исправил проблему в тестах с удалением категорий и жанров.
Дело было в том, что их адрес определялся по слагу, а не по id.

https://stackoverflow.com/questions/32201257/django-rest-framework-access-item-detail-by-slug-instead-of-id